### PR TITLE
update redux* dependencies to v2; move unused deps to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
     "rimraf": "^2.3.4"
   },
   "peerDependencies": {
-    "redux": "^1.0.0 || 1.0.0-rc",
-    "redux-devtools": "^1.0.2"
+    "redux": "^2.0.0",
+    "redux-devtools": "^2.1.0",
+    "react-redux": "^2.0.0"
   },
   "dependencies": {
-    "react-redux": "^0.8.2",
-    "redux": "^1.0.0-rc",
-    "redux-devtools": "^1.0.2"
+    "redux-devtools": "^2.1.0"
   }
 }


### PR DESCRIPTION
I updated all the `redux` related dependencies to the latest major versions.

I also noticed that `redux` and `react-redux` weren't used anywhere in `src/` so I moved them out of `dependencies` and into `peerDependencies`. Let me know if that's not ok and I can revert that part of the change.

I tested both examples with the new versions and everything worked as expected. I also read the changelogs of the `redux` projects and didn't see anything that would break this, so I think it's a safe upgrade.