### PR TITLE
small formatting fix

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -95,17 +95,17 @@ export default class Slider extends Component {
   orChildrenCount = (value, defaultValue) => {
     let count = Children.count(this.props.children);
     switch (count) {
-      case 0:
-        return value.length > 0 ? value : defaultValue;
-      case value.length:
-        return value;
-      case defaultValue.length:
-        return defaultValue;
-      default:
-        if (value.length !== count || defaultValue.length !== count) {
-          console.warn(this.constructor.displayName + ': Number of values does not match number of children.');
-        }
-        return this.linspace(this.props.min, this.props.max, count);
+    case 0:
+      return value.length > 0 ? value : defaultValue;
+    case value.length:
+      return value;
+    case defaultValue.length:
+      return defaultValue;
+    default:
+      if (value.length !== count || defaultValue.length !== count) {
+        console.warn(this.constructor.displayName + ': Number of values does not match number of children.');
+      }
+      return this.linspace(this.props.min, this.props.max, count);
     }
   }
 

--- a/src/SliderMonitor.js
+++ b/src/SliderMonitor.js
@@ -101,8 +101,8 @@ export default class SliderMonitor extends Component {
         return this.pauseReplay();
       }
 
-      if(this.state.replaySpeed === 'Live') {
-        this.startRealtimeReplay()
+      if (this.state.replaySpeed === 'Live') {
+        this.startRealtimeReplay();
       } else {
         this.startReplay();
       }
@@ -136,7 +136,8 @@ export default class SliderMonitor extends Component {
       jumpToState(0);
       stateIndex = 0;
     } else if (currentStateIndex === computedStates.length - 2) {
-      return jumpToState(currentStateIndex + 1);
+      jumpToState(currentStateIndex + 1);
+      return;
     } else {
       stateIndex = currentStateIndex + 1;
       jumpToState(currentStateIndex + 1);
@@ -144,7 +145,7 @@ export default class SliderMonitor extends Component {
 
     let counter = stateIndex;
     let timer = setInterval(() => {
-      if(counter + 1 <= computedStates.length - 1) {
+      if (counter + 1 <= computedStates.length - 1) {
         jumpToState(counter + 1);
       }
       counter++;

--- a/src/SliderMonitor.js
+++ b/src/SliderMonitor.js
@@ -242,14 +242,14 @@ export default class SliderMonitor extends Component {
   changeReplaySpeed = () => {
     let replaySpeed;
     switch (this.state.replaySpeed) {
-      case '1x':
-        replaySpeed = '2x';
-        break;
-      case '2x':
-        replaySpeed = 'Live';
-        break;
-      default:
-        replaySpeed = '1x';
+    case '1x':
+      replaySpeed = '2x';
+      break;
+    case '2x':
+      replaySpeed = 'Live';
+      break;
+    default:
+      replaySpeed = '1x';
     }
 
     this.setState({ replaySpeed });


### PR DESCRIPTION
Fixes this: 

	$ npm install

	> fsevents@1.0.5 install /Users/tieme/github/redux-slider-monitor/node_modules/fsevents
	> node-pre-gyp install --fallback-to-build

	[fsevents] Success: "/Users/tieme/github/redux-slider-monitor/node_modules/fsevents/lib/binding/Release/node-v47-darwin-x64/fse.node" is installed via remote

	> expect@1.13.0 postinstall /Users/tieme/github/redux-slider-monitor/node_modules/expect
	> node ./npm-scripts/postinstall.js


	> redux-slider-monitor@0.6.4 prepublish /Users/tieme/github/redux-slider-monitor
	> npm run lint && npm run clean && npm run build


	> redux-slider-monitor@0.6.4 lint /Users/tieme/github/redux-slider-monitor
	> eslint src examples


	src/SliderMonitor.js
	  104:6   error  Keyword "if" must be followed by whitespace  space-after-keywords
	  105:34  error  Missing semicolon                            semi
	  139:6   error  Expected no return value                     consistent-return
	  140:11  error  Unexpected 'else' after 'return'             no-else-return
	  147:6   error  Keyword "if" must be followed by whitespace  space-after-keywords

	✖ 5 problems (5 errors, 0 warnings)

Didn't fix this one: 

`140:11  error  Unexpected 'else' after 'return'             no-else-return`

That's caused by [this bug](https://joshc.io/javascript/eslint/2015/07/23/no-else-return-can-be-harmful.html) in the outdated eslint you're using. 

Updating eslint will give your some more errors btw: 

     $ npm run lint

    > redux-slider-monitor@0.6.4 lint /Users/tieme/github/redux-slider-monitor
    > eslint src examples


    /Users/tieme/github/redux-slider-monitor/src/Slider.js
        1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
        1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment
        1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
       98:7  error  Expected indentation of 4 space characters but found 6                  indent
       99:9  error  Expected indentation of 6 space characters but found 8                  indent
      100:7  error  Expected indentation of 4 space characters but found 6                  indent
      101:9  error  Expected indentation of 6 space characters but found 8                  indent
      102:7  error  Expected indentation of 4 space characters but found 6                  indent
      103:9  error  Expected indentation of 6 space characters but found 8                  indent
      104:7  error  Expected indentation of 4 space characters but found 6                  indent
      105:9  error  Expected indentation of 6 space characters but found 8                  indent
      108:9  error  Expected indentation of 6 space characters but found 8                  indent

    /Users/tieme/github/redux-slider-monitor/src/SliderMonitor.js
        1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
        1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment
        1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      245:7  error  Expected indentation of 4 space characters but found 6                  indent
      246:9  error  Expected indentation of 6 space characters but found 8                  indent
      247:9  error  Expected indentation of 6 space characters but found 8                  indent
      248:7  error  Expected indentation of 4 space characters but found 6                  indent
      249:9  error  Expected indentation of 6 space characters but found 8                  indent
      250:9  error  Expected indentation of 6 space characters but found 8                  indent
      251:7  error  Expected indentation of 4 space characters but found 6                  indent
      252:9  error  Expected indentation of 6 space characters but found 8                  indent

    /Users/tieme/github/redux-slider-monitor/examples/counter/actions/CounterActions.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/components/Counter.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/constants/ActionTypes.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/containers/App.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/containers/CounterApp.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/index.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/reducers/counter.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/counter/reducers/index.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/actions/TodoActions.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/components/Footer.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/components/Header.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/components/MainSection.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/components/TodoItem.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/components/TodoTextInput.js
       1:1   error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
       1:1   error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
       1:1   error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment
      43:15  error  Expected indentation of 8 space characters but found 14                 indent
      44:15  error  Expected indentation of 8 space characters but found 14                 indent
      45:14  error  Expected indentation of 6 space characters but found 13                 indent

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/constants/ActionTypes.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/constants/TodoFilters.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/containers/App.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/containers/TodoApp.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/index.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/reducers/index.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    /Users/tieme/github/redux-slider-monitor/examples/todomvc/reducers/todos.js
      1:1  error  Rule 'no-reserved-keys' was removed and replaced by: quote-props        no-reserved-keys
      1:1  error  Rule 'no-wrap-func' was removed and replaced by: no-extra-parens        no-wrap-func
      1:1  error  Rule 'spaced-line-comment' was removed and replaced by: spaced-comment  spaced-line-comment

    ✖ 89 problems (89 errors, 0 warnings)
