### PR TITLE
Use css-element-queries resize sensor instead of `window on resize`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "redux-devtools": "^3.0.0"
   },
   "dependencies": {
+    "css-element-queries": "^0.3.2",
     "redux-devtools-themes": "^1.0.0"
   }
 }

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -129,14 +129,16 @@ export default class Slider extends Component {
 
   componentDidMount = () => {
     if (typeof window !== 'undefined') {
-      window.addEventListener('resize', this.updateSlider);
+      const ResizeSensor = require('css-element-queries/src/ResizeSensor');
+      const slider = findDOMNode(this.refs.slider);
+      this.sliderResizeSensor = new ResizeSensor(slider, this.updateSlider);
     }
     this.updateSlider();
   }
 
   componentWillUnmount = () => {
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('resize', this.updateSlider);
+    if (this.sliderResizeSensor) {
+      this.sliderResizeSensor.detach();
     }
   }
 


### PR DESCRIPTION
Sorry, I overlooked element resize (e.g. react-dock right mode) at #20, so I used [css-element-queries](https://github.com/marcj/css-element-queries) to solve it, not listen window resize.