### PR TITLE
Adjust slider dock height (white bottom stripe)

### DIFF
--- a/src/SliderMonitor.js
+++ b/src/SliderMonitor.js
@@ -249,10 +249,10 @@ export default class SliderMonitor extends Component {
 
   containerStyle = (theme) => {
     return {
-      height: '85%',
+      height: '100%',
       fontFamily: 'monospace',
       position: 'relative',
-      padding: '0.7rem',
+      padding: '0 0.7rem 0.7rem 0.7rem',
       display: 'flex',
       justifyContent: 'space-between',
       alignItems: 'center',


### PR DESCRIPTION
Hi,

I applied the SliderMonitor dock to the react/material-ui applcation. Unfortunately, browser adds a bottom white stripe below the slider panel.
Proposed pull-request should fix this issue.

Marcin