### PR TITLE
Optimize devui imports

### DIFF
--- a/src/SliderButton.js
+++ b/src/SliderButton.js
@@ -1,6 +1,6 @@
 import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'devui';
+import Button from 'devui/lib/Button';
 
 export default class SliderButton extends (PureComponent || Component) {
   static propTypes = {

--- a/src/SliderMonitor.js
+++ b/src/SliderMonitor.js
@@ -2,7 +2,10 @@ import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import * as themes from 'redux-devtools-themes';
 import { ActionCreators } from 'redux-devtools';
-import { Toolbar, Slider, Button, SegmentedControl, Divider } from 'devui';
+import { Toolbar, Divider } from 'devui/lib/Toolbar';
+import Slider from 'devui/lib/Slider';
+import Button from 'devui/lib/Button';
+import SegmentedControl from 'devui/lib/SegmentedControl';
 
 import reducer from './reducers';
 import SliderButton from './SliderButton';


### PR DESCRIPTION
Use individual devui components instead of importing the entire ui library. This can make the build process faster and build a smaller bundle file.